### PR TITLE
fix(examples): Fixed txwrapper examples

### DIFF
--- a/txwrapper-example/README.md
+++ b/txwrapper-example/README.md
@@ -2,4 +2,9 @@
 
 Examples on how to handle foreign assets with [txwrapper](https://github.com/paritytech/txwrapper-core/).
 
-To run these examples, simply cd into this directory and run `yarn build && yarn <fee|transfer>`.
+To run these examples, you must have a `Asset Hub Rococo Local` node running. To do this,
+download the `polkado-parachain` binary from the [`polkadot-sdk` repo](https://github.com/paritytech/polkadot-sdk/releases/latest)
+or clone it and run `cargo build --release -p polkadot-parachain-bin` and then run
+`./target/release/polkadot-parachain --chain asset-hub-rococo-local`.
+
+Once the node is running, simply cd into this directory and run `yarn build && yarn <fee|transfer>`.

--- a/txwrapper-example/common/util.ts
+++ b/txwrapper-example/common/util.ts
@@ -11,7 +11,7 @@ import { createMetadata, OptionsWithMeta } from '@substrate/txwrapper-polkadot';
 import { fetch } from 'undici';
 
 /**
- * Send a JSONRPC request to the node at wss://polkadot-asset-hub-rpc.dwellir.com.
+ * Send a JSONRPC request to the node at http://polkadot-asset-hub-rpc.dwellir.com.
  *
  * @param method - The JSONRPC request method.
  * @param params - The JSONRPC request params.
@@ -20,7 +20,7 @@ export function rpcToLocalNode(
 	method: string,
 	params: any[] = [],
 ): Promise<any> {
-	return fetch('wss://polkadot-asset-hub-rpc.dwellir.com', {
+	return fetch('http://localhost:9944', {
 		body: JSON.stringify({
 			id: 1,
 			jsonrpc: '2.0',

--- a/txwrapper-example/package.json
+++ b/txwrapper-example/package.json
@@ -3,8 +3,8 @@
   "packageManager": "yarn@4.1.0",
   "scripts": {
     "build": "substrate-exec-rimraf ./lib && substrate-exec-tsc",
-    "transfer": "node ./lib/foreignAssetTransfer.js",
-    "fee": "node ./lib/foreignAssetTransferWithFee.js"
+    "transfer": "node ./lib/src/foreignAssetTransfer.js",
+    "fee": "node ./lib/src/foreignAssetTransferWithFee.js"
   },
   "devDependencies": {
     "@polkadot/api": "^10.11.3",

--- a/txwrapper-example/src/foreignAssetTransfer.ts
+++ b/txwrapper-example/src/foreignAssetTransfer.ts
@@ -169,8 +169,8 @@ async function main(): Promise<void> {
 
 	console.log(
 		`\nDecoded Transaction\n  To: ${
-			(txInfo.method.args.dest as { id: string })?.id
-		}\n` + `  Amount: ${txInfo.method.args.value}\n`,
+			(txInfo.method.args.target as { id: string })?.id
+		}\n` + `  Amount: ${txInfo.method.args.amount}\n`,
 	);
 }
 

--- a/txwrapper-example/src/foreignAssetTransferWithFee.ts
+++ b/txwrapper-example/src/foreignAssetTransferWithFee.ts
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
 		},
 		{
 			address: deriveAddress(alice.publicKey, PolkadotSS58Format.westend),
-            assetId: 1337,
+      assetId: { parents: 0, interior : { X2: [{PalletInstance: 50}, {GeneralIndex: 1337}]}},
 			blockHash,
 			blockNumber: registry
 				.createType('BlockNumber', block.header.number)
@@ -170,8 +170,8 @@ async function main(): Promise<void> {
 
 	console.log(
 		`\nDecoded Transaction\n  To: ${
-			(txInfo.method.args.dest as { id: string })?.id
-		}\n` + `  Amount: ${txInfo.method.args.value}\n`,
+			(txInfo.method.args.target as { id: string })?.id
+		}\n` + `  Amount: ${txInfo.method.args.amount}\n`,
 	);
 }
 

--- a/txwrapper-example/yarn.lock
+++ b/txwrapper-example/yarn.lock
@@ -887,20 +887,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@polkadot-api/metadata-builders": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/substrate-bindings": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/substrate-client": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/utils": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  peerDependencies:
-    rxjs: ">=7.8.0"
-  checksum: 572a5538013131321722924a8ec4c4a3f18dfe76fc4897d77a65b2aa7e3162c5d11adab30111fd8489ab6952b7bd875f544e863b8cc0e54948233c6d736335e5
-  languageName: node
-  linkType: hard
-
 "@polkadot-api/client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
@@ -915,24 +901,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: d30789f6171fce9887139b88e832d121489fbe1694aa6919fb1c4a37e6ac39ba1f8e19caa76c0007fd815820f1c1b1de6e12169c6b638c580eb74eb0137b4b34
-  languageName: node
-  linkType: hard
-
 "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
   checksum: 4c47c978806bc62fff1b5788241cd59457d62ebe347b401b0a621d56d301f7b205aeb20ade24b67c2a5d63a497738694cb4030f79d5009460d17a546e8723f81
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/json-rpc-provider@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/json-rpc-provider@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: fb028b1d16e2c39e5130f90e340691afcd1c45f08f39f56e3a46aa5a87f2bdfd2f71ad81f348d7fe78aceae483c50be4eb55e572f5fdf273beab5ac7b253a59c
   languageName: node
   linkType: hard
 
@@ -943,16 +915,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/metadata-builders@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/metadata-builders@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@polkadot-api/substrate-bindings": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/utils": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  checksum: 64705f32b9f7d43af759db28161e244f1ea45d5a4214a2a7592b1a4b3922378f1bfe50ad659defe93f23a63da306e50df9602a757656200cf1e50387b1a11842
-  languageName: node
-  linkType: hard
-
 "@polkadot-api/metadata-builders@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/metadata-builders@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
@@ -960,18 +922,6 @@ __metadata:
     "@polkadot-api/substrate-bindings": 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
     "@polkadot-api/utils": 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   checksum: 7fb6264fbe7a49c8f8848fb36f51fa9882c504fc026b0ac28cf2d83890cfa2c2ce7a3dd8c01aed28b991cb4d4a64910557111afe8792375aea2aba1b2aabe233
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/substrate-bindings@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/substrate-bindings@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  dependencies:
-    "@noble/hashes": ^1.3.1
-    "@polkadot-api/utils": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@scure/base": ^1.1.1
-    scale-ts: ^1.4.3
-  checksum: c17caa73feaee67edff6e106453f4ef54fe2e14fc921e1fa5e1bd4e8e3f4af8e01802ce3959df072f5997d843c9ad4916b0b52103fdf58c7bf006911be326585
   languageName: node
   linkType: hard
 
@@ -987,13 +937,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/substrate-client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/substrate-client@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 655272b98490e084b948e2c798e0f7d4ba7d90d33b9f24b4d01dd2a5ef6e7e31bf523dd6de602354a3911e897c55bdc32dc24f3b504ce22f27a8e40063296bb4
-  languageName: node
-  linkType: hard
-
 "@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
@@ -1001,32 +944,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/utils@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0":
-  version: 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-  resolution: "@polkadot-api/utils@npm:0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0"
-  checksum: 48ff709170ee7abad50f784f1123532b6b39725ab709da59fc9ddd859568753456b46c9c42d5aa56cad3d9fa0af27e46ed0650697df840f0ef2c023bd3a512f1
-  languageName: node
-  linkType: hard
-
 "@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
   checksum: 0bf7b078a53f1eaf2f4cec3c41f3e82fc5afb4a347dcbc7b538723aeb1b4893834a2f1aeed425443a25ee0e1a6472c85d8be600e73a6d25ea16a0748d25c00bf
-  languageName: node
-  linkType: hard
-
-"@polkadot/api-augment@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/api-augment@npm:10.12.1"
-  dependencies:
-    "@polkadot/api-base": 10.12.1
-    "@polkadot/rpc-augment": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-augment": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: 430f4eba309cc7d4d3508d1bc5d949d6312cb96739a93a257f490ff0261d20a4b61a894afcbb13661f4a5e40060f5080a3c710c619b98a0e39e249cdb668072e
   languageName: node
   linkType: hard
 
@@ -1045,19 +966,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/api-base@npm:10.12.1"
-  dependencies:
-    "@polkadot/rpc-core": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/util": ^12.6.2
-    rxjs: ^7.8.1
-    tslib: ^2.6.2
-  checksum: 9eb9ccdfae93e5bd333bb669dde00e2ed1242142d689f49ae56b501fbfcd5981018eec31e3d7539bc345ebaf856d0c57cc971a2e62f6f1f914ffe68b9eee4544
-  languageName: node
-  linkType: hard
-
 "@polkadot/api-base@npm:10.12.4":
   version: 10.12.4
   resolution: "@polkadot/api-base@npm:10.12.4"
@@ -1068,24 +976,6 @@ __metadata:
     rxjs: ^7.8.1
     tslib: ^2.6.2
   checksum: f5fcdbec09004e0b8110897f71cd63f9134658d35ab55af341569faecaad68cb0ab24b578faca230a2b866ea573e2c5a4de6f27b005ea1eb7caa0ffd8765c1d9
-  languageName: node
-  linkType: hard
-
-"@polkadot/api-derive@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/api-derive@npm:10.12.1"
-  dependencies:
-    "@polkadot/api": 10.12.1
-    "@polkadot/api-augment": 10.12.1
-    "@polkadot/api-base": 10.12.1
-    "@polkadot/rpc-core": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/util": ^12.6.2
-    "@polkadot/util-crypto": ^12.6.2
-    rxjs: ^7.8.1
-    tslib: ^2.6.2
-  checksum: fdd725f8b28b4f213e2b61ab6e99cddff26add60cd9a605ebf59b210c9f1a8b79879c169d13e9a0ff712cec9fd64281a235c704c08a3877b33b349a7b13c00c4
   languageName: node
   linkType: hard
 
@@ -1107,32 +997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:10.12.1, @polkadot/api@npm:^10.11.3":
-  version: 10.12.1
-  resolution: "@polkadot/api@npm:10.12.1"
-  dependencies:
-    "@polkadot/api-augment": 10.12.1
-    "@polkadot/api-base": 10.12.1
-    "@polkadot/api-derive": 10.12.1
-    "@polkadot/keyring": ^12.6.2
-    "@polkadot/rpc-augment": 10.12.1
-    "@polkadot/rpc-core": 10.12.1
-    "@polkadot/rpc-provider": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-augment": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/types-create": 10.12.1
-    "@polkadot/types-known": 10.12.1
-    "@polkadot/util": ^12.6.2
-    "@polkadot/util-crypto": ^12.6.2
-    eventemitter3: ^5.0.1
-    rxjs: ^7.8.1
-    tslib: ^2.6.2
-  checksum: 25ef0b7ae5fbc740a9a0e4fd2536475ec473edfe29f94a97b5ea776c7d02b6a95a937564e7a171a459d678784818053a7444dff8302fafc594241f8db29ab440
-  languageName: node
-  linkType: hard
-
-"@polkadot/api@npm:10.12.4, @polkadot/api@npm:^10.12.2":
+"@polkadot/api@npm:10.12.4, @polkadot/api@npm:^10.11.3, @polkadot/api@npm:^10.12.2":
   version: 10.12.4
   resolution: "@polkadot/api@npm:10.12.4"
   dependencies:
@@ -1182,19 +1047,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/rpc-augment@npm:10.12.1"
-  dependencies:
-    "@polkadot/rpc-core": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: 845ea139f6526de67de1afb7e0f4542e29b63af3efdc98934676031eb174b84e49a17a212f06441c400cd234453414f78fff2b8b0c0c5cd54d2364cf2fbb6010
-  languageName: node
-  linkType: hard
-
 "@polkadot/rpc-augment@npm:10.12.4":
   version: 10.12.4
   resolution: "@polkadot/rpc-augment@npm:10.12.4"
@@ -1205,20 +1057,6 @@ __metadata:
     "@polkadot/util": ^12.6.2
     tslib: ^2.6.2
   checksum: 81285b6d465ca8faf2d72cff14d5e5cd0ad1a5dca2a8308891b86475de498f811ebc76820f7f63ded8d519f3cce978a91525ce97f431d62d2af8d70ccddd8c20
-  languageName: node
-  linkType: hard
-
-"@polkadot/rpc-core@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/rpc-core@npm:10.12.1"
-  dependencies:
-    "@polkadot/rpc-augment": 10.12.1
-    "@polkadot/rpc-provider": 10.12.1
-    "@polkadot/types": 10.12.1
-    "@polkadot/util": ^12.6.2
-    rxjs: ^7.8.1
-    tslib: ^2.6.2
-  checksum: d9f12597110e237fbb0f8f1c4c86cc8fcc598eddfd4ace0de00928fae446f3ddd8208183b462984738c149048cd51c9556c76d12568b27b77cc6ede4177db700
   languageName: node
   linkType: hard
 
@@ -1233,30 +1071,6 @@ __metadata:
     rxjs: ^7.8.1
     tslib: ^2.6.2
   checksum: 0463396fb90d5dce130b61dcf79f4cbc752605ed614230e3e98bb7044b590b3d22abc452159168ac8d13c50c130d3fa1880dc6132f949402e4c831a5d2d1d943
-  languageName: node
-  linkType: hard
-
-"@polkadot/rpc-provider@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/rpc-provider@npm:10.12.1"
-  dependencies:
-    "@polkadot/keyring": ^12.6.2
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-support": 10.12.1
-    "@polkadot/util": ^12.6.2
-    "@polkadot/util-crypto": ^12.6.2
-    "@polkadot/x-fetch": ^12.6.2
-    "@polkadot/x-global": ^12.6.2
-    "@polkadot/x-ws": ^12.6.2
-    "@substrate/connect": 0.8.7
-    eventemitter3: ^5.0.1
-    mock-socket: ^9.3.1
-    nock: ^13.5.0
-    tslib: ^2.6.2
-  dependenciesMeta:
-    "@substrate/connect":
-      optional: true
-  checksum: 29246fa825be3f4f2eb34d63a1ef17ecda1b2e6423cfcb6c119ecbfdf15c18230d085fc111ff4739c07748cc3923a4829ec5deefaebb54b8b6a1252b80d5da39
   languageName: node
   linkType: hard
 
@@ -1284,18 +1098,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/types-augment@npm:10.12.1"
-  dependencies:
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: eec5f93331174a587dd804fe4f00b5409b7f775af3d8b8db3289d804d165a1a840311d44e54beaacf0b1ae323ac51905725aad32f9e48ff68a84a3afec03e726
-  languageName: node
-  linkType: hard
-
 "@polkadot/types-augment@npm:10.12.4":
   version: 10.12.4
   resolution: "@polkadot/types-augment@npm:10.12.4"
@@ -1305,17 +1107,6 @@ __metadata:
     "@polkadot/util": ^12.6.2
     tslib: ^2.6.2
   checksum: c10c1bce36880428ea3f01a214b8bab5835378bd692eaf3780ed58621fe2e1eb9ee51d58d50c990bf5f1c27cf955b65dad4c1dc84a6333940d8f4ce5f71c75a0
-  languageName: node
-  linkType: hard
-
-"@polkadot/types-codec@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/types-codec@npm:10.12.1"
-  dependencies:
-    "@polkadot/util": ^12.6.2
-    "@polkadot/x-bigint": ^12.6.2
-    tslib: ^2.6.2
-  checksum: 800f4172d0504d860e97f6894a8f43bde5ae20abe9f7b0a3a0e85cb8cfbeb80ce77fb381bda49d1defe30f4756939649b607dc4c3660e40c335e1b21651f28e5
   languageName: node
   linkType: hard
 
@@ -1330,17 +1121,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/types-create@npm:10.12.1"
-  dependencies:
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: ff051f75c5e692f89de4e7686311a66e7b889a398efefcd373a67a18796c06a80266eed55726a97850b1e4e430ca13004895394a8e368acbe5e030e55c20269f
-  languageName: node
-  linkType: hard
-
 "@polkadot/types-create@npm:10.12.4":
   version: 10.12.4
   resolution: "@polkadot/types-create@npm:10.12.4"
@@ -1349,20 +1129,6 @@ __metadata:
     "@polkadot/util": ^12.6.2
     tslib: ^2.6.2
   checksum: ceb2eade4501990436bf1303c4a6a42d934d8961186403504af044088b61ab8b09d3af62545b260d0e2f9f7a1cb19b08940f874ac15655196d4571a2dba86f5f
-  languageName: node
-  linkType: hard
-
-"@polkadot/types-known@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/types-known@npm:10.12.1"
-  dependencies:
-    "@polkadot/networks": ^12.6.2
-    "@polkadot/types": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/types-create": 10.12.1
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: dbd4b4ac107908606d24fc5ec1a5be9cc1a972d1345b45908b310dae7fe09fc9f4f49c03edbec4694ed8b2de4c771f98ec228aa155a968b13e82513f33db9eeb
   languageName: node
   linkType: hard
 
@@ -1380,16 +1146,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:10.12.1":
-  version: 10.12.1
-  resolution: "@polkadot/types-support@npm:10.12.1"
-  dependencies:
-    "@polkadot/util": ^12.6.2
-    tslib: ^2.6.2
-  checksum: a6eb886fb0e1c56f7c22e96a9255d6dac53fd4e30248c96950867a58854b542943b9143a69052b3b73a596ec2b2665b8857ed98267acf0e55fbeebb1670ca125
-  languageName: node
-  linkType: hard
-
 "@polkadot/types-support@npm:10.12.4":
   version: 10.12.4
   resolution: "@polkadot/types-support@npm:10.12.4"
@@ -1400,23 +1156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:10.12.1, @polkadot/types@npm:^10.11.3":
-  version: 10.12.1
-  resolution: "@polkadot/types@npm:10.12.1"
-  dependencies:
-    "@polkadot/keyring": ^12.6.2
-    "@polkadot/types-augment": 10.12.1
-    "@polkadot/types-codec": 10.12.1
-    "@polkadot/types-create": 10.12.1
-    "@polkadot/util": ^12.6.2
-    "@polkadot/util-crypto": ^12.6.2
-    rxjs: ^7.8.1
-    tslib: ^2.6.2
-  checksum: 6184f50bef018b1fa11e3caaf851dc6fc7510c3dc56f81cfbde1b401f30ddd8ac73083770af41f3c8b3aa76beb4784d9ddb772460ab77c933628385090ab290c
-  languageName: node
-  linkType: hard
-
-"@polkadot/types@npm:10.12.4":
+"@polkadot/types@npm:10.12.4, @polkadot/types@npm:^10.11.3":
   version: 10.12.4
   resolution: "@polkadot/types@npm:10.12.4"
   dependencies:
@@ -1660,29 +1400,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect-known-chains@npm:^1.0.7":
-  version: 1.1.0
-  resolution: "@substrate/connect-known-chains@npm:1.1.0"
-  checksum: 6fef15a5686e9344d72b6f2e4b486ea18e53f93d7024caeaa39ee2bc74804fd77f74d03aca3609c59f6dbf27ad52f393b1e4ba0899613eaf046d09d1c4b7a9d3
-  languageName: node
-  linkType: hard
-
 "@substrate/connect-known-chains@npm:^1.1.1":
   version: 1.1.2
   resolution: "@substrate/connect-known-chains@npm:1.1.2"
   checksum: 4e6f68219d87f56e4129209109870e8d270247a6e5a3cd143af72e9ebf3ae77b05e1d3fc9c583c108941c1371890714f6eef10e259069b1020af829d26fb1e9a
-  languageName: node
-  linkType: hard
-
-"@substrate/connect@npm:0.8.7":
-  version: 0.8.7
-  resolution: "@substrate/connect@npm:0.8.7"
-  dependencies:
-    "@substrate/connect-extension-protocol": ^2.0.0
-    "@substrate/connect-known-chains": ^1.0.7
-    "@substrate/light-client-extension-helpers": ^0.0.3
-    smoldot: 2.0.21
-  checksum: 8390d03f463690b63193363024c4c9edafebebe1722acd95d07a8177630d85039d7115cf1c502d1d8254adbea97e5b3cf49ec36841cebefeb0408201e39e8fc5
   languageName: node
   linkType: hard
 
@@ -1724,23 +1445,6 @@ __metadata:
     substrate-exec-tsc: ./scripts/substrate-exec-tsc.cjs
     substrate-update-pjs-deps: ./scripts/substrate-update-pjs-deps.cjs
   checksum: 64631ec9e3b4ea3395b830293ba543e3897d05c79376402da2635610476c6f82b187f0ff8b2c272d29cad3814eed579771d98a5c29533776531786c4a1d2efc6
-  languageName: node
-  linkType: hard
-
-"@substrate/light-client-extension-helpers@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@substrate/light-client-extension-helpers@npm:0.0.3"
-  dependencies:
-    "@polkadot-api/client": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/json-rpc-provider": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/json-rpc-provider-proxy": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@polkadot-api/substrate-client": 0.0.1-12c4b0432a814086c3c1a3b8052b31c72c2c9ad3.1.0
-    "@substrate/connect-extension-protocol": ^2.0.0
-    "@substrate/connect-known-chains": ^1.0.7
-    rxjs: ^7.8.1
-  peerDependencies:
-    smoldot: 2.x
-  checksum: a2e4a1df8f76c10c7ef3193cd4c7633beaea59e840afa71b74a5d90bdd8b335f1ec7b847b3c30e84be6e59bd25a8240549860d3016e3851a14aced45eac339a7
   languageName: node
   linkType: hard
 
@@ -5033,7 +4737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scale-ts@npm:^1.4.3, scale-ts@npm:^1.6.0":
+"scale-ts@npm:^1.6.0":
   version: 1.6.0
   resolution: "scale-ts@npm:1.6.0"
   checksum: 2cd6d3e31ea78621fe2e068eedc3beb6a3cfc338c9033f04ec3e355b4b08e134febad655c54a80272a50737136a27436f9d14d6525b126e621a3b77524111056
@@ -5108,15 +4812,6 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: b5167a7142c1da704c0e3af85c402002b597081dd9575031a90b4f229ca5678e9a36e8a374f1814c8156a725d17008ae3bde63b92f9cfd132526379e580bec8b
-  languageName: node
-  linkType: hard
-
-"smoldot@npm:2.0.21":
-  version: 2.0.21
-  resolution: "smoldot@npm:2.0.21"
-  dependencies:
-    ws: ^8.8.1
-  checksum: 464f23dd20e8156ab63dfdccf719da9a9e245b4c1581844c3d76ab64384154f578261810d9f3d1957739577a1bccbf51b6a7467f7862f092c45b47f8e1e7b9a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updated the rpc endpoint to work with a local `Asset Hub Rococo` node, since the public endpoints timed out, and updated the instructions accordingly. Also fixed the decoding of the examples and the `assetId`, since rococo uses the `asset conversion pallet`